### PR TITLE
Capturing group with unit tests

### DIFF
--- a/src/main/java/net/amygdalum/regexparser/GroupNode.java
+++ b/src/main/java/net/amygdalum/regexparser/GroupNode.java
@@ -3,13 +3,28 @@ package net.amygdalum.regexparser;
 public class GroupNode implements RegexNode {
 
 	private RegexNode subNode;
+	private int groupNumber;
 
 	public GroupNode(RegexNode subNode) {
 		this.subNode = subNode;
+		this.groupNumber = 0;
+	}
+	
+	public GroupNode(RegexNode subNode, int groupNumber) {
+		this.subNode = subNode;
+		this.groupNumber = groupNumber;
 	}
 
 	public RegexNode getSubNode() {
 		return subNode;
+	}
+
+	public boolean isCapturingGroup(){
+		return groupNumber > 0;
+	}
+
+	public int getGroupNumber() {
+		return groupNumber;
 	}
 
 	@Override
@@ -22,6 +37,7 @@ public class GroupNode implements RegexNode {
 		try {
 			GroupNode clone = (GroupNode) super.clone();
 			clone.subNode = subNode.clone();
+			clone.groupNumber = groupNumber;
 			return clone;
 		} catch (CloneNotSupportedException e) {
 			return null;

--- a/src/test/java/net/amygdalum/regexparser/RegexParserTest.java
+++ b/src/test/java/net/amygdalum/regexparser/RegexParserTest.java
@@ -6,7 +6,9 @@ import static java.lang.Character.MIN_VALUE;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -233,7 +235,42 @@ public class RegexParserTest {
 		RegexParser parser = new RegexParser("(B)");
 		RegexNode node = parser.parse();
 
+		assertThat(node, reflectiveEqualTo((RegexNode) new GroupNode(new SingleCharNode('B'), 1)));
+	}
+
+	@Test
+	public void testCapturingGroup() throws Exception {
+		GroupNode ncg = new GroupNode(new SingleCharNode('C'),1);
+		assertThat(ncg.isCapturingGroup(), equalTo(true));
+	}
+	
+	@Test
+	public void testGroupNumber() throws Exception {		
+		RegexParser parser = new RegexParser("((A)(B(C)))");
+		GroupNode group1 = (GroupNode)parser.parse();
+		assertEquals(1, group1.getGroupNumber());
+
+		ConcatNode cn = (ConcatNode)group1.getSubNode();
+		GroupNode group2 = (GroupNode)cn.getSubNodes().get(0);
+		assertEquals(2, group2.getGroupNumber());
+
+		GroupNode group3 = (GroupNode)cn.getSubNodes().get(1);
+		assertEquals(3, group3.getGroupNumber());
+
+		cn = (ConcatNode)group3.getSubNode();
+		GroupNode group4 = (GroupNode)cn.getSubNodes().get(1);
+		assertEquals(4, group4.getGroupNumber());
+	}
+
+	@Test
+	public void testNotCapturingGroup() throws Exception {
+		RegexParser parser = new RegexParser("(?:B)");
+		RegexNode node = parser.parse();
+
 		assertThat(node, reflectiveEqualTo((RegexNode) new GroupNode(new SingleCharNode('B'))));
+
+		GroupNode ncg = new GroupNode(new SingleCharNode('C'));
+		assertThat(ncg.isCapturingGroup(), equalTo(false));
 	}
 
 	@Test
@@ -241,7 +278,7 @@ public class RegexParserTest {
 		RegexParser parser = new RegexParser("a(B)");
 		RegexNode node = parser.parse();
 
-		assertThat(node, reflectiveEqualTo((RegexNode) ConcatNode.inSequence(new SingleCharNode('a'), new GroupNode(new SingleCharNode('B')))));
+		assertThat(node, reflectiveEqualTo((RegexNode) ConcatNode.inSequence(new SingleCharNode('a'), new GroupNode(new SingleCharNode('B'),1))));
 	}
 
 	@Test


### PR DESCRIPTION
Implemented group numbering and tested with the example in the following page https://docs.oracle.com/javase/tutorial/essential/regex/groups.html 

When a open parenthesis is found the group increase its group number except for groups that begins with "?:"  